### PR TITLE
Add podcasts and youtube channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Un insieme di communities, podcast, canali Twitch/Youtube e molto altro del tech
 
 * [Pillole di bit](https://www.pilloledib.it/)
 
+* [Il podcast di Marco's Box](https://podcasters.spotify.com/pod/show/marcosbox)
+
 
 <div align="right">
   <b><a href="#indice">↥ Back To Top</a></b>

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ Un insieme di communities, podcast, canali Twitch/Youtube e molto altro del tech
 
 * [Storie di Developers](https://open.spotify.com/show/5rDJu3qScB9YR5yZtgjm62?si=c189ddf7f1074756)
 
+* [DataKnightmare: L'algoritmico è politico](https://dataknightmare.eu/)
+
 <div align="right">
   <b><a href="#indice">↥ Back To Top</a></b>
 </div>

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Un insieme di communities, podcast, canali Twitch/Youtube e molto altro del tech
 
 * [DataKnightmare: L'algoritmico è politico](https://dataknightmare.eu/)
 
+* [Ciao, Internet! con Matteo Flora](https://open.spotify.com/show/5q7jh01YLFtru7iqUlj6lu)
 <div align="right">
   <b><a href="#indice">↥ Back To Top</a></b>
 </div>

--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ Un insieme di communities, podcast, canali Twitch/Youtube e molto altro del tech
 
 * [Giuseppe Funicello](https://www.youtube.com/@giuppidev)
 
+* [Christian Varisco](https://www.youtube.com/@christianvarisco)
+
 
 <div align="right">
   <b><a href="#indice">↥ Back To Top</a></b>

--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ Un insieme di communities, podcast, canali Twitch/Youtube e molto altro del tech
 * [Ciao, Internet! con Matteo Flora](https://open.spotify.com/show/5q7jh01YLFtru7iqUlj6lu)
 
 * [Algoritmi - Datapizza](https://open.spotify.com/show/6TMBvIx2tWVA8AEPDU027j)
+
+* [Pillole di bit](https://www.pilloledib.it/)
+
+
 <div align="right">
   <b><a href="#indice">↥ Back To Top</a></b>
 </div>

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ Un insieme di communities, podcast, canali Twitch/Youtube e molto altro del tech
 * [DataKnightmare: L'algoritmico è politico](https://dataknightmare.eu/)
 
 * [Ciao, Internet! con Matteo Flora](https://open.spotify.com/show/5q7jh01YLFtru7iqUlj6lu)
+
+* [Algoritmi - Datapizza](https://open.spotify.com/show/6TMBvIx2tWVA8AEPDU027j)
 <div align="right">
   <b><a href="#indice">↥ Back To Top</a></b>
 </div>


### PR DESCRIPTION
# Descrizione

Ho aggiunto dei podcast e canali youtube che reputo validi, nella fattispecie:
- Youtube: 
   - Christian varisco con il suo format Caffè sviluppo (@CVarisco insieme al suo co-host @EmanueleGurini)
- Podcasts:
   - Pillole di bit: tratta di moltissime cose che concernono il mondo IT
   - Algoritmi: tratta principalmente del mondo AI e Data science
   - Il podcast di marco's box: tratta del mondo open source e del software libero
   - Data knightmare: esula un pò dal mondo tech ma tratta delle ripercussioni che il mondo tech ha sul mondo
   - Ciao internet!: tratta della parte più "giuridica" del mondo IT, molto di privacy e reputation.

Se qualcosa va contro le policy del repo ditemi pure che faccio revert 😄 